### PR TITLE
readme 修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# #Chat-space設計
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|user_id|string|null: false, foreign_key: true|
+
+### Association
+has_many :messages_id
+has_many :gruops_id, through: :groups_users
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|text|null: false|
+|user_id|string|null: false|
+
+### Association
+belongs_to :user_id
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|string|null: false, foreign_key: true|
+|group_id|string|null: false, foreign_key: true|
+
+### Association
+has_many :users_id, through: :groups_users
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+belongs_to :groups_id
+belongs_to :users_id

--- a/README.md
+++ b/README.md
@@ -1,42 +1,46 @@
-# #Chat-space設計
+# Chat-space設計
+
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
 |email|string|null: false, add_index:e-mail, unique:true|
 |password|string|null: false|
-|user_id|string|null: false, foreign_key: true|
+|name|string|null: false,add_index:name, unique:true|
 
 ### Association
-has_many :messages_id
+has_many :messages
 has_many :groups_users
-has_many :gruops_id, through: :groups_users
+has_many :gruops, through: :groups_users
 
 ## messagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|text|text|null: false|
-|user_id|string|null: false|
+|img|string|
+|body|text|
+|groups_id|integer|
+|user_id|integer|
 
 ### Association
-belongs_to :user_id
+belongs_to :user
+belongs_to :group
 
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|string|null: false, foreign_key: true|
-|group_id|string|null: false, foreign_key: true|
+|name|string|null: false|
 
 ### Association
-gas_many :groups_id
-has_many :users_id, through: :groups_users
+has_many :groups_users
+has_many :messages
+has_many :users, through: :groups_users
 
 ## groups_usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|integer|null: false, foreign_key: true|
+|group|integer|null: false, foreign_key: true|
 
 ### Association
-belongs_to :groups_id
-belongs_to :users_id
+belongs_to :group
+belongs_to :user

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 |------|----|-------|
 |email|string|null: false, add_index:e-mail, unique:true|
 |password|string|null: false|
-|name|string|null: false,add_index:name, unique:true|
+|name|string|null: false,index:true, unique:true|
 
 ### Association
 has_many :messages
@@ -17,8 +17,8 @@ has_many :gruops, through: :groups_users
 |------|----|-------|
 |img|string|
 |body|text|
-|group_id|integer|null: false, foreign_key: true|
-|user_id|integer|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 
 ### Association
 belongs_to :user
@@ -37,8 +37,8 @@ has_many :users, through: :groups_users
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
+|group_id|references|null: false, foreign_key: true|
 
 ### Association
 belongs_to :group

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ has_many :gruops, through: :groups_users
 |------|----|-------|
 |img|string|
 |body|text|
-|groups_id|integer|
-|user_id|integer|
+|group_id|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
 
 ### Association
 belongs_to :user
@@ -37,8 +37,8 @@ has_many :users, through: :groups_users
 ## groups_usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user|integer|null: false, foreign_key: true|
-|group|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 ### Association
 belongs_to :group

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ has_many :messages
 has_many :users, through: :groups_users
 
 ## groups_usersテーブル
-
 |Column|Type|Options|
 |------|----|-------|
 |user|integer|null: false, foreign_key: true|

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # #Chat-space設計
-
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|email|string|null: false|
+|email|string|null: false, add_index:e-mail, unique:true|
 |password|string|null: false|
 |user_id|string|null: false, foreign_key: true|
 
 ### Association
 has_many :messages_id
+has_many :groups_users
 has_many :gruops_id, through: :groups_users
 
 ## messagesテーブル
@@ -27,6 +27,7 @@ belongs_to :user_id
 |group_id|string|null: false, foreign_key: true|
 
 ### Association
+gas_many :groups_id
 has_many :users_id, through: :groups_users
 
 ## groups_usersテーブル


### PR DESCRIPTION
WHAT  チャットスペースでのエンティティとそれぞれ必要な属性をReadmeに表示した
WHY　チャットスペースを実装する際にどのテーブルが使用されているかわかりやすくなるから

実装することにより、複雑なデータを効率的に操作するために実装した。